### PR TITLE
Update channel ordering to use name only

### DIFF
--- a/app/controllers/api/v1/channels_controller.rb
+++ b/app/controllers/api/v1/channels_controller.rb
@@ -73,12 +73,12 @@ module Api
       end
 
       def channel_feeds
-        channel_feeds = Community.filter_channel_feeds.exclude_incomplete_channels.exclude_deleted_channels.exclude_not_recommended.with_all_includes
+        channel_feeds = Community.filter_channel_feeds.exclude_incomplete_channels.exclude_deleted_channels.exclude_not_recommended.with_all_includes.ordered_pos_name
         render json: Api::V1::ChannelSerializer.new(channel_feeds , { params: { current_account: current_account } }).serializable_hash.to_json
       end
 
       def newsmast_channels
-        newsmast_channels = Community.filter_newsmast_channels.exclude_incomplete_channels.exclude_deleted_channels.exclude_not_recommended.with_all_includes
+        newsmast_channels = Community.filter_newsmast_channels.exclude_incomplete_channels.exclude_deleted_channels.exclude_not_recommended.with_all_includes.ordered_pos_name
         if newsmast_channels.present?
           render json: Api::V1::ChannelSerializer.new(newsmast_channels , { params: { current_account: current_remote_account } }).serializable_hash.to_json
         else

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -215,7 +215,7 @@ class Community < ApplicationRecord
       .order('patchwork_community_types.sorting_index ASC')
   }
 
-  scope :ordered_pos_name, -> { order('patchwork_communities.position ASC, patchwork_communities.name ASC') }
+  scope :ordered_pos_name, -> { order('patchwork_communities.name ASC') }
 
   scope :filter_channels, -> { where(patchwork_communities: { channel_type: Community.channel_types[:channel] }).exclude_deleted_channels }
 


### PR DESCRIPTION
Modified the `ordered_pos_name` scope in the Community model to order channels by name only, removing position from the ordering. Updated channel_feeds and newsmast_channels actions to use the revised ordering.