### PR TITLE
Feat/assign civicrm role on join working group

### DIFF
--- a/app/controllers/api/v1/joined_working_groups_controller.rb
+++ b/app/controllers/api/v1/joined_working_groups_controller.rb
@@ -135,16 +135,19 @@ module Api
       def ensure_civicrm_membership_eligibility!
         # Remote account requests do not have local user-email context for membership validation.
         return if params[:instance_domain].present?
-        return if params[:working_group_id].blank?
+        return render_membership_not_eligible if params[:working_group_id].blank?
 
         email = @account&.user&.email
         return render_membership_not_eligible if email.blank?
 
         membership_result = CivicrmMembershipCheckService.new(
           email,
-          working_group_id: params[:working_group_id]
+          working_group_id: params[:working_group_id],
+          force_remote: true
         ).call
         return if membership_result.valid? && membership_result.values_present
+
+        return render_membership_not_eligible if membership_result.error_message.blank?
 
         render_validation_failed([membership_result.error_message])
       rescue NameError => e

--- a/app/controllers/api/v1/joined_working_groups_controller.rb
+++ b/app/controllers/api/v1/joined_working_groups_controller.rb
@@ -144,7 +144,7 @@ module Api
           email,
           working_group_id: params[:working_group_id]
         ).call
-        return if membership_result.valid?
+        return if membership_result.valid? && membership_result.values_present
 
         render_validation_failed([membership_result.error_message])
       rescue NameError => e

--- a/app/controllers/api/v1/joined_working_groups_controller.rb
+++ b/app/controllers/api/v1/joined_working_groups_controller.rb
@@ -21,7 +21,7 @@ module Api
       skip_before_action :verify_key!
       before_action :check_authorization_header
       before_action :set_authenticated_account
-      before_action :ensure_civicrm_membership_eligibility!, only: [:create]
+      before_action :ensure_civicrm_membership_eligibility!, only: [:create], if: :check_civicrm_membership_enabled?
       before_action :load_joined_channels, only: [:index, :set_primary]
 
       def index
@@ -148,10 +148,6 @@ module Api
       end
 
       def ensure_civicrm_membership_eligibility!
-        # Remote account requests do not have local user-email context for membership validation.
-        # return if params[:instance_domain].present?
-        return render_membership_not_eligible unless check_civicrm_membership_enabled?
-
         patchwork_community = find_patchwork_community(params[:id])
         return render_membership_not_eligible unless patchwork_community
 

--- a/app/controllers/api/v1/joined_working_groups_controller.rb
+++ b/app/controllers/api/v1/joined_working_groups_controller.rb
@@ -6,7 +6,7 @@ module Api
       skip_before_action :verify_key!
       before_action :check_authorization_header
       before_action :set_authenticated_account
-      before_action :ensure_civicrm_membership_eligibility!, only: [:create], if: :check_civicrm_membership_enabled?
+      before_action :ensure_civicrm_membership_eligibility!, only: [:create]
       before_action :load_joined_channels, only: [:index, :set_primary]
 
       def index
@@ -134,7 +134,8 @@ module Api
 
       def ensure_civicrm_membership_eligibility!
         # Remote account requests do not have local user-email context for membership validation.
-        return if params[:instance_domain].present?
+        # return if params[:instance_domain].present?
+        return render_membership_not_eligible unless check_civicrm_membership_enabled?
         return render_membership_not_eligible if params[:working_group_id].blank?
 
         email = @account&.user&.email

--- a/app/controllers/api/v1/joined_working_groups_controller.rb
+++ b/app/controllers/api/v1/joined_working_groups_controller.rb
@@ -3,6 +3,21 @@
 module Api
   module V1
     class JoinedWorkingGroupsController < ApiController
+      CIVICRM_WORKING_GROUP_IDS_BY_COMMUNITY_NAME = {
+        'Atlas' => 20,
+        'Community Engagement' => 19,
+        'Ethical Framework' => 21,
+        'EWS in LMICS' => 22,
+        'Models, Data, Methods Repo' => 23,
+        'Advisory' => 24,
+        'Collaborative' => 25,
+        'Communications' => 26,
+        'Events' => 27,
+        'Finance' => 28,
+        'Governance' => 29,
+        'Committee - Membership' => 30
+      }.freeze
+
       skip_before_action :verify_key!
       before_action :check_authorization_header
       before_action :set_authenticated_account
@@ -136,14 +151,19 @@ module Api
         # Remote account requests do not have local user-email context for membership validation.
         # return if params[:instance_domain].present?
         return render_membership_not_eligible unless check_civicrm_membership_enabled?
-        return render_membership_not_eligible if params[:working_group_id].blank?
+
+        patchwork_community = find_patchwork_community(params[:id])
+        return render_membership_not_eligible unless patchwork_community
+
+        working_group_id = CIVICRM_WORKING_GROUP_IDS_BY_COMMUNITY_NAME[patchwork_community.name]
+        return render_membership_not_eligible unless working_group_id
 
         email = @account&.user&.email
         return render_membership_not_eligible if email.blank?
 
         membership_result = CivicrmMembershipCheckService.new(
           email,
-          working_group_id: params[:working_group_id],
+          working_group_id: working_group_id,
           force_remote: true
         ).call
         return if membership_result.valid? && membership_result.values_present

--- a/app/controllers/api/v1/joined_working_groups_controller.rb
+++ b/app/controllers/api/v1/joined_working_groups_controller.rb
@@ -6,6 +6,7 @@ module Api
       skip_before_action :verify_key!
       before_action :check_authorization_header
       before_action :set_authenticated_account
+      before_action :ensure_civicrm_membership_eligibility!, only: [:create]
       before_action :load_joined_channels, only: [:index, :set_primary]
 
       def index
@@ -129,6 +130,37 @@ module Api
         return render_unauthorized unless @account
 
         @account
+      end
+
+      def ensure_civicrm_membership_eligibility!
+        # Remote account requests do not have local user-email context for membership validation.
+        return if params[:instance_domain].present?
+        return if params[:working_group_id].blank?
+
+        email = @account&.user&.email
+        return render_membership_not_eligible if email.blank?
+
+        membership_result = CivicrmMembershipCheckService.new(
+          email,
+          working_group_id: params[:working_group_id]
+        ).call
+        return if membership_result.valid?
+
+        render_validation_failed([membership_result.error_message])
+      rescue NameError => e
+        Rails.logger.error("CiviCRM membership service unavailable: #{e.class} #{e.message}")
+        render_membership_not_eligible
+      rescue StandardError => e
+        Rails.logger.error("CiviCRM membership eligibility check failed: #{e.class} #{e.message}")
+        render_membership_not_eligible
+      end
+
+      def render_membership_not_eligible
+        message = I18n.t(
+          'api.account.errors.membership_not_eligible',
+          default: 'Membership is not eligible for this action'
+        )
+        render_validation_failed([message])
       end
     end
   end

--- a/app/controllers/api/v1/joined_working_groups_controller.rb
+++ b/app/controllers/api/v1/joined_working_groups_controller.rb
@@ -6,7 +6,7 @@ module Api
       skip_before_action :verify_key!
       before_action :check_authorization_header
       before_action :set_authenticated_account
-      before_action :ensure_civicrm_membership_eligibility!, only: [:create]
+      before_action :ensure_civicrm_membership_eligibility!, only: [:create], if: :check_civicrm_membership_enabled?
       before_action :load_joined_channels, only: [:index, :set_primary]
 
       def index
@@ -153,6 +153,11 @@ module Api
       rescue StandardError => e
         Rails.logger.error("CiviCRM membership eligibility check failed: #{e.class} #{e.message}")
         render_membership_not_eligible
+      end
+
+      def check_civicrm_membership_enabled?
+        raw_value = ENV.fetch('CHECK_CIVICRM_MEMBERSHIP', nil)
+        raw_value.present? && ActiveModel::Type::Boolean.new.cast(raw_value)
       end
 
       def render_membership_not_eligible

--- a/app/services/civicrm_membership_check_service.rb
+++ b/app/services/civicrm_membership_check_service.rb
@@ -34,11 +34,9 @@ class CivicrmMembershipCheckService
 
     body = response.parsed_response
     body = parse_response_body(response_body) unless body.is_a?(Hash)
-    user_groups = extract_user_groups(body)
-    values_present = values_present?(body)
-    return valid_result(user_groups, values_present: true) if values_present
+    return invalid_result if response_values(body).empty?
 
-    invalid_result
+    valid_result(extract_user_groups(body), values_present: true)
   rescue StandardError => e
     Rails.logger.error("CiviCRM membership check failed: #{e.class} #{normalize_utf8(e.message)}")
     invalid_result
@@ -187,12 +185,7 @@ class CivicrmMembershipCheckService
   end
 
   def extract_user_groups(body)
-    return [] unless body.is_a?(Hash)
-
-    values = body["values"] || body[:values]
-    return [] unless values.present?
-
-    results = results_from_values(values)
+    results = response_values(body).select { |value| value.is_a?(Hash) }
     return [] if results.empty?
 
     results
@@ -200,17 +193,6 @@ class CivicrmMembershipCheckService
       .map { |group| group.to_s.strip }
       .reject(&:blank?)
       .uniq
-  end
-
-  def results_from_values(values)
-    case values
-    when Array
-      values.select { |value| value.is_a?(Hash) }
-    when Hash
-      values.values.select { |value| value.is_a?(Hash) }
-    else
-      []
-    end
   end
 
   def groups_from_result(result)
@@ -226,17 +208,12 @@ class CivicrmMembershipCheckService
     end
   end
 
-  def values_present?(body)
-    values = body["values"] || body[:values]
+  def response_values(body)
+    return [] unless body.is_a?(Hash)
+    return [] unless body.key?("values") || body.key?(:values)
 
-    case values
-    when Array
-      values.any?
-    when Hash
-      values.any?
-    else
-      false
-    end
+    values = body["values"] || body[:values]
+    values.is_a?(Array) ? values : []
   end
 
   def valid_result(user_groups = [], values_present: true)

--- a/app/services/civicrm_membership_check_service.rb
+++ b/app/services/civicrm_membership_check_service.rb
@@ -9,7 +9,7 @@ class CivicrmMembershipCheckService
 
   CONTACT_GET_PATH = "/civicrm/ajax/api4/Contact/get"
 
-  Result = Struct.new(:valid?, :error_message, :user_groups, keyword_init: true)
+  Result = Struct.new(:valid?, :error_message, :user_groups, :values_present, keyword_init: true)
 
   def initialize(email, working_group_id:, force_remote: false)
     @email = email
@@ -35,8 +35,8 @@ class CivicrmMembershipCheckService
     body = response.parsed_response
     body = parse_response_body(response_body) unless body.is_a?(Hash)
     user_groups = extract_user_groups(body)
-    return valid_result(user_groups) if body.is_a?(Hash) && body["count"].to_i.positive?
-    return valid_result(user_groups) if values_present?(body)
+    values_present = values_present?(body)
+    return valid_result(user_groups, values_present: true) if values_present
 
     invalid_result
   rescue StandardError => e
@@ -239,15 +239,16 @@ class CivicrmMembershipCheckService
     end
   end
 
-  def valid_result(user_groups = [])
-    Result.new(valid?: true, error_message: nil, user_groups: user_groups)
+  def valid_result(user_groups = [], values_present: true)
+    Result.new(valid?: true, error_message: nil, user_groups: user_groups, values_present: values_present)
   end
 
   def invalid_result
     Result.new(
       valid?: false,
       error_message: I18n.t("api.account.errors.membership_not_eligible", default: "Membership is not eligible for this action"),
-      user_groups: []
+      user_groups: [],
+      values_present: false
     )
   end
 end

--- a/app/services/civicrm_membership_check_service.rb
+++ b/app/services/civicrm_membership_check_service.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require "httparty"
+require "json"
+require "uri"
+
+class CivicrmMembershipCheckService
+  include HTTParty
+
+  CONTACT_GET_PATH = "/civicrm/ajax/api4/Contact/get"
+
+  Result = Struct.new(:valid?, :error_message, :user_groups, keyword_init: true)
+
+  def initialize(email, working_group_id:, force_remote: false)
+    @email = email
+    @working_group_id = working_group_id
+    @force_remote = force_remote
+  end
+
+  def call
+    return valid_result unless force_remote? || feature_enabled?
+    return invalid_result if @email.blank?
+    return invalid_result if working_group_ids.empty?
+    return valid_result if allowlisted_email? && !force_remote?
+    return invalid_result unless config_present?
+
+    response = self.class.get(endpoint_url, headers: request_headers, query: { params: request_params.to_json })
+    response_body = response.respond_to?(:body) ? normalize_utf8(response.body) : ""
+
+    unless response.success?
+      Rails.logger.error("CiviCRM membership check unauthorized/failed: status=#{response.code} body=#{response_body}")
+      return invalid_result
+    end
+
+    body = response.parsed_response
+    body = parse_response_body(response_body) unless body.is_a?(Hash)
+    user_groups = extract_user_groups(body)
+    return valid_result(user_groups) if body.is_a?(Hash) && body["count"].to_i.positive?
+    return valid_result(user_groups) if values_present?(body)
+
+    invalid_result
+  rescue StandardError => e
+    Rails.logger.error("CiviCRM membership check failed: #{e.class} #{normalize_utf8(e.message)}")
+    invalid_result
+  end
+
+  private
+
+  def force_remote?
+    @force_remote
+  end
+
+  def feature_enabled?
+    ActiveModel::Type::Boolean.new.cast(ENV.fetch("CSID_MEMBERSHIP_CHECK_ENABLED", "false"))
+  end
+
+  def config_present?
+    base_url.present? && auth_token.present?
+  end
+
+  def base_url
+    raw = ENV.fetch("CIVICRM_BASE_URL", nil).to_s.strip
+    return "" if raw.blank?
+
+    candidate = raw.match?(%r{\Ahttps?://}i) ? raw : "https://#{raw}"
+    uri = URI.parse(candidate)
+
+    # Enforce HTTPS for port 443 and normalize URL without trailing slash.
+    uri.scheme = "https" if uri.port == 443 || uri.scheme.blank?
+    uri.to_s.chomp("/")
+  rescue URI::InvalidURIError
+    ""
+  end
+
+  def auth_token
+    ENV.fetch("CIVICRM_AUTH_TOKEN", nil).to_s.strip.gsub(/\A'+|'+\z/, "")
+  end
+
+  def endpoint_url
+    "#{base_url}#{CONTACT_GET_PATH}"
+  end
+
+  def request_headers
+    {
+      "accept" => "application/json, text/plain, */*",
+      "x-civi-auth" => formatted_auth_token,
+      "x-requested-with" => "XMLHttpRequest",
+      "skipinterceptor" => "true"
+    }
+  end
+
+  def formatted_auth_token
+    return auth_token if auth_token.match?(/\ABearer\s+/i)
+
+    "Bearer #{auth_token}"
+  end
+
+  def request_params
+    {
+      select: [
+        "id",
+        "contact_type",
+        "display_name",
+        "first_name",
+        "last_name",
+        "nick_name",
+        "job_title",
+        "current_employer",
+        "image_URL",
+        "email.email",
+        "phone.phone",
+        "address.city",
+        "address.country_id:label",
+        "GROUP_CONCAT(DISTINCT group_contact.group_id:label) AS user_groups",
+        "GROUP_CONCAT(DISTINCT group_contact.group_id) AS user_group_ids",
+        "membership.status_id:label",
+        "membership.end_date",
+        "Individual_Information.Bio",
+        "Individual_Information.Areas_of_interest",
+        "Individual_Information.Working_Group",
+        "Individual_Information.Community_Role",
+        "Socials.Website",
+        "Socials.LinkedIn",
+        "Socials.Mastodon",
+        "Socials.Bluesky",
+        "Socials.GitHub"
+      ],
+      join: [
+        ["Email AS email", "LEFT", ["email.is_primary", "=", true]],
+        ["Phone AS phone", "LEFT", ["phone.is_primary", "=", true]],
+        ["Address AS address", "LEFT", ["address.is_primary", "=", true]],
+        ["GroupContact AS group_contact", "LEFT", ["group_contact.status", "=", "'Added'"]],
+        ["Membership AS membership", "LEFT", ["id", "=", "membership.contact_id"]]
+      ],
+      groupBy: ["id"],
+      where: [
+        ["is_deleted", "=", false],
+        ["email.email", "=", @email],
+        ["groups", "IN", working_group_ids]
+      ]
+    }
+  end
+
+  def working_group_ids
+    Array(@working_group_id)
+      .flat_map { |value| value.to_s.split(",") }
+      .map { |value| value.to_s.strip }
+      .reject(&:blank?)
+      .filter_map { |value| Integer(value, 10) rescue nil }
+      .uniq
+  end
+
+  def allowlisted_email?
+    allowlisted_emails.include?(@email.to_s.strip.downcase)
+  end
+
+  def allowlisted_emails
+    allowed_mails = ENV.fetch("CSID_MEMBERSHIP_ALLOWLIST_EMAILS", nil).to_s.strip
+    return [] if allowed_mails.blank?
+
+    parse_allowlisted_emails(allowed_mails)
+      .map { |email| email.to_s.strip.downcase }
+      .reject(&:blank?)
+      .uniq
+  end
+
+  def parse_allowlisted_emails(raw_value)
+    return JSON.parse(raw_value) if raw_value.start_with?("[")
+
+    raw_value.split(/\s*,\s*/)
+  rescue JSON::ParserError
+    raw_value.split(/\s*,\s*/)
+  end
+
+  def parse_response_body(response_body)
+    JSON.parse(response_body)
+  rescue JSON::ParserError
+    {}
+  end
+
+  def normalize_utf8(value)
+    value
+      .to_s
+      .dup
+      .force_encoding(Encoding::UTF_8)
+      .scrub
+  end
+
+  def extract_user_groups(body)
+    return [] unless body.is_a?(Hash)
+
+    values = body["values"] || body[:values]
+    return [] unless values.present?
+
+    results = results_from_values(values)
+    return [] if results.empty?
+
+    results
+      .flat_map { |result| groups_from_result(result) }
+      .map { |group| group.to_s.strip }
+      .reject(&:blank?)
+      .uniq
+  end
+
+  def results_from_values(values)
+    case values
+    when Array
+      values.select { |value| value.is_a?(Hash) }
+    when Hash
+      values.values.select { |value| value.is_a?(Hash) }
+    else
+      []
+    end
+  end
+
+  def groups_from_result(result)
+    groups = result["user_groups"] || result[:user_groups]
+
+    case groups
+    when String
+      groups.split(/[;,]/)
+    when Array
+      groups
+    else
+      []
+    end
+  end
+
+  def values_present?(body)
+    values = body["values"] || body[:values]
+
+    case values
+    when Array
+      values.any?
+    when Hash
+      values.any?
+    else
+      false
+    end
+  end
+
+  def valid_result(user_groups = [])
+    Result.new(valid?: true, error_message: nil, user_groups: user_groups)
+  end
+
+  def invalid_result
+    Result.new(
+      valid?: false,
+      error_message: I18n.t("api.account.errors.membership_not_eligible", default: "Membership is not eligible for this action"),
+      user_groups: []
+    )
+  end
+end


### PR DESCRIPTION
### Summary
- Add CiviCRM membership validation before joining a working group.
- Verify the user’s email belongs to the requested CiviCRM group.
- Block joins when configuration, group ID, email, API response, or response values are missing.
- Handle API failures safely with validation errors and logging.

### Configuration
Requires CHECK_CIVICRM_MEMBERSHIP, CIVICRM_BASE_URL, and CIVICRM_AUTH_TOKEN.